### PR TITLE
close #3 configure route & navigation

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,7 +1,12 @@
+import 'package:deeplink/app_router.dart';
+import 'package:deeplink/notifier/deeplink_state_notifier.dart';
 import 'package:deeplink/screens/home_screen.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:flutter/material.dart';
 
-class App extends StatelessWidget {
+class App extends HookWidget {
+  static GlobalKey<NavigatorState> navigationKey = GlobalKey<NavigatorState>();
   final String? url;
 
   const App({
@@ -11,10 +16,15 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    context.read(deeplinkStateNotifier)..load(url: url);
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData.dark(),
-      home: HomScreen(title: url.toString()),
+      home: HomeScreen(),
+      navigatorKey: navigationKey,
+      onGenerateRoute: (setting) {
+        return AppRouter(settings: setting).onGenerateRoute();
+      },
     );
   }
 }

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:deeplink/configs/route_config.dart';
+import 'package:flutter_deep_linking/flutter_deep_linking.dart' as dl;
+
+class AppRouter {
+  static const String HOME = '/home';
+  static const String PRODUCTS = '/products';
+  static const String NOT_FOUND = '/404';
+
+  late RouteConfig routeConfig;
+  final RouteSettings settings;
+
+  AppRouter({required this.settings}) {
+    routeConfig = RouteConfig(settings: settings);
+  }
+
+  Route<dynamic>? onGenerateRoute() {
+    RouteSettings settings = this.settings;
+    dl.Router router = routeConfig.buildAppRouter();
+    return router.onGenerateRoute(settings);
+  }
+
+  String defaultRoute() => HOME;
+}

--- a/lib/configs/route_config.dart
+++ b/lib/configs/route_config.dart
@@ -1,0 +1,53 @@
+import 'package:deeplink/app_router.dart';
+import 'package:deeplink/screens/home_screen.dart';
+import 'package:deeplink/screens/not_found_screen.dart';
+import 'package:deeplink/screens/product_detail_screen.dart';
+import 'package:deeplink/screens/products_screen.dart';
+import 'package:flutter/material.dart' as m;
+import 'package:flutter_deep_linking/flutter_deep_linking.dart';
+
+class RouteConfig {
+  final m.RouteSettings settings;
+  RouteConfig({
+    required this.settings,
+  });
+
+  String _removeSlash(String string) {
+    return string.replaceFirst("/", "");
+  }
+
+  Router buildAppRouter() {
+    return Router(
+      routes: [
+        Route(
+          matcher: Matcher.path(_removeSlash(AppRouter.HOME)),
+          materialBuilder: (m.BuildContext _, RouteResult result) => HomeScreen(),
+        ),
+        Route(
+          matcher: Matcher.path(_removeSlash(AppRouter.PRODUCTS)),
+          materialBuilder: (m.BuildContext _, RouteResult result) {
+            String? keywords = result.uri.queryParameters['keywords'];
+            Map<String, String> queryParameters = {...result.uri.queryParameters}..remove('keywords');
+            return ProductsScreen(
+              keywords: keywords ?? "",
+              queryParameters: queryParameters,
+            );
+          },
+          routes: [
+            Route(
+              matcher: Matcher.path('{id}'),
+              materialBuilder: (m.BuildContext _, RouteResult result) {
+                String id = result['id']!;
+                return ProductDetailScreen(id: id);
+              },
+            )
+          ],
+        ),
+        Route(
+          matcher: Matcher.any(),
+          materialBuilder: (m.BuildContext _, RouteResult result) => NotFoundScreen(),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:deeplink/app.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:uni_links/uni_links.dart';
 
 void main() async {
@@ -9,7 +10,9 @@ void main() async {
     StreamBuilder<String?>(
       stream: linkStream,
       builder: (context, snapshot) {
-        return App(url: snapshot.data ?? url);
+        return ProviderScope(
+          child: App(url: snapshot.data ?? url),
+        );
       },
     ),
   );

--- a/lib/notifier/deeplink_state_notifier.dart
+++ b/lib/notifier/deeplink_state_notifier.dart
@@ -1,0 +1,17 @@
+import 'package:deeplink/app.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+class DeeplinkStateNotifier extends ChangeNotifier {
+  void load({String? url}) {
+    if (url == null || App.navigationKey.currentContext == null) return;
+    WidgetsBinding.instance?.addPostFrameCallback((timeStamp) {
+      Navigator.of(App.navigationKey.currentContext!).pushNamed(url);
+    });
+  }
+}
+
+final deeplinkStateNotifier = ChangeNotifierProvider<DeeplinkStateNotifier>((ref) {
+  return DeeplinkStateNotifier();
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,6 +62,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_deep_linking:
+    dependency: "direct main"
+    description:
+      name: flutter_deep_linking
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -72,6 +93,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.2"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+4"
   js:
     dependency: transitive
     description:
@@ -79,6 +114,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.1"
   matcher:
     dependency: transitive
     description:
@@ -107,6 +149,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -126,6 +175,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   uni_links: ^0.5.1
+  flutter_deep_linking: ^0.2.1
+  hooks_riverpod: ^0.14.0+4
+  flutter_hooks: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Test:
```
xcrun simctl openurl booted "https://vtenh.com/products/apple"
xcrun simctl openurl booted "https://vtenh.com/products?keywords=123&category=1"
```

### Navigator:
```dart
Navigator.of(context).pushNamed("https://vtenh.com/products/apple")
Navigator.of(context).pushNamed("https://vtenh.com/products?keywords=123&category=1")
```

### Demo:
Result will be same on app close.

https://user-images.githubusercontent.com/29684683/131216273-348bddf1-fe2b-4f93-b4b6-ffd585f27bff.mov



